### PR TITLE
chore: bump Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,24 @@ name: Rust CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: 1.73
-        components: clippy
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
 
-    - name: Run tests
-      run: cargo test
+      - name: Run tests
+        run: cargo test
 
-    - name: Run clippy
-      run: cargo clippy -- -D warnings
+      - name: Run clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - target: x86_64-apple-darwin
             archive: zip
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.4
@@ -30,4 +30,4 @@ jobs:
           SRC_DIR: v8-heap-cli
           RUSTTARGET: ${{ matrix.target }}
           EXTRA_FILES: "v8-heap-cli/readme.md LICENSE"
-          TOOLCHAIN_VERSION: 1.73
+          TOOLCHAIN_VERSION: stable

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -23,7 +23,7 @@ parameters:
   - name: channel
     displayName: 🚀 Rust channel
     type: string
-    default: 1.73
+    default: 1.76
 
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates


### PR DESCRIPTION
One of the dependencies now requires Rust >=1.74.